### PR TITLE
Fix issue where full rows are skipped

### DIFF
--- a/src/solver.h
+++ b/src/solver.h
@@ -9,6 +9,7 @@
 #define NUM_LETTERS 26              // number of letters in the alphabet
 
 int compare_arrays(char arr1[GRID_SIZE][GRID_SIZE], char arr2[GRID_SIZE][GRID_SIZE]);
+int is_repeated_word(char grid[GRID_SIZE][GRID_SIZE], char word[], int row);
 void print_grid(char grid[GRID_SIZE][GRID_SIZE]);
 int fits_in_row(char solution[GRID_SIZE][GRID_SIZE], char unplaced[GRID_SIZE][GRID_SIZE],
                 char word[], int row);

--- a/tests/test_is_repeated_word.c
+++ b/tests/test_is_repeated_word.c
@@ -1,0 +1,90 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "../src/solver.h"
+
+void test_is_repeated_word_empty_board() {
+    char board[GRID_SIZE][GRID_SIZE] = {
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'}
+    };
+    char word[] = "aloha";
+
+    // Test cases
+    int result = is_repeated_word(board, word, 0);
+    assert(0 == result);
+}
+
+void test_is_repeated_word_row_current_row() {
+    char board[GRID_SIZE][GRID_SIZE] = {
+        {'a', 'l', 'o', 'h', 'a'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'}
+    };
+    char word[] = "aloha";
+
+    // Test cases
+    int result = is_repeated_word(board, word, 0);
+    assert(0 == result);
+}
+
+void test_is_repeated_word_row_past_row() {
+    char board[GRID_SIZE][GRID_SIZE] = {
+        {'a', 'l', 'o', 'h', 'a'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'}
+    };
+    char word[] = "aloha";
+
+    // Test cases
+    int result = is_repeated_word(board, word, 1);
+    assert(1 == result);
+}
+
+void test_is_repeated_word_row_future_row() {
+    char board[GRID_SIZE][GRID_SIZE] = {
+        {'.', '.', '.', '.', '.'},
+        {'a', 'l', 'o', 'h', 'a'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'},
+        {'.', '.', '.', '.', '.'}
+    };
+    char word[] = "aloha";
+
+    // Test cases
+    int result = is_repeated_word(board, word, 0);
+    assert(1 == result);
+}
+
+void test_is_repeated_word_column() {
+    char board[GRID_SIZE][GRID_SIZE] = {
+        {'a', '.', '.', '.', '.'},
+        {'l', '.', '.', '.', '.'},
+        {'o', '.', '.', '.', '.'},
+        {'h', '.', '.', '.', '.'},
+        {'a', '.', '.', '.', '.'}
+    };
+    char word[] = "aloha";
+
+    // Test cases
+    int result = is_repeated_word(board, word, 0);
+    assert(1 == result);
+}
+
+int main() {
+    test_is_repeated_word_empty_board();
+    test_is_repeated_word_row_current_row();
+    test_is_repeated_word_row_past_row();
+    test_is_repeated_word_row_future_row();
+    test_is_repeated_word_column();
+
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Information

### Type
fix

### Scope
solver

### Description
Fix issue where full rows were being skipped

### Body
If a row were full when the solver started, it would skip the word, causing the solver to not move to the next row and miss solutions.

### Issue Number
17

### Pull Request Number
18

## References
[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
